### PR TITLE
Add WP Coding Standards config and sniffs

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,25 @@
+# This file is for unifying the coding style for different editors and IDEs
+# editorconfig.org
+
+# WordPress Coding Standards
+# http://make.wordpress.org/core/handbook/coding-standards/
+
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+indent_style = tab
+
+[js-tests/**/*.js]
+indent_style = space
+indent_size = 2
+
+[*.json]
+indent_style = space
+indent_size = 2
+
+[*.txt,wp-config-sample.php]
+end_of_line = crlf

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,8 @@ matrix:
       env: WP_VERSION=latest WP_MULTISITE=1
 
 before_script:
-  - bash bin/install-wp-tests.sh wordpress_test root '' localhost $WP_VERSION 
+  - bash bin/install-wp-tests.sh wordpress_test root '' localhost $WP_VERSION
 
-script: phpunit
+script:
+  - phpunit
+  - vendor/bin/phpcs --standard=phpcs.ruleset.xml

--- a/composer.json
+++ b/composer.json
@@ -1,15 +1,19 @@
 {
-	"name": "fusioneng/speed-bumps",
-	"authors": [
-		{
-			"name": "Fusion Engineering",
-			"email": "tech@fusion.net"
-		}
-  	],
-  	"require-dev": {
-		"wp-coding-standards/wpcs": "dev-develop"
-  	},
-	"require": {
-		"querypath/QueryPath": ">=3.0.0"
-	}
+  "name": "fusioneng/speed-bumps",
+  "authors": [
+    {
+      "name": "Fusion Engineering",
+      "email": "tech@fusion.net"
+    }
+  ],
+  "require-dev": {
+    "wp-coding-standards/wpcs": "dev-develop"
+    },
+  "require": {
+    "querypath/QueryPath": ">=3.0.0"
+  },
+  "scripts": {
+    "post-install-cmd": "\"vendor/bin/phpcs\" --config-set installed_paths vendor/wp-coding-standards/wpcs",
+    "post-update-cmd" : "\"vendor/bin/phpcs\" --config-set installed_paths vendor/wp-coding-standards/wpcs"
+  }
 }

--- a/phpcs.ruleset.xml
+++ b/phpcs.ruleset.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0"?>
+<ruleset name="Shortcake">
+	<description>Sniffs for the coding standards of the Speed Bumps plugin</description>
+
+	<extensions>*.php</extensions>
+	<exclude-pattern>/vendor/*</exclude-pattern>
+
+	<rule ref="WordPress-VIP">
+		<exclude name="WordPress.CSRF.NonceVerification" />
+		<exclude name="WordPress.VIP.SuperGlobalInputUsage" />
+		<exclude name="WordPress.VIP.ValidatedSanitizedInput" />
+	</rule>
+</ruleset>


### PR DESCRIPTION
Adds the WP Coding Standards ruleset and editorconfig file to this project, and includes them in the Travis build tests.

After merging this with your branch, try running `vendor/bin/phpcs --standard=phpcs.ruleset.xml ./` and see if you can fix all the lint issues found?
  