### PR TITLE
Rework the contraints logic in a way I understand better

### DIFF
--- a/inc/class-speed-bumps-element-constraints.php
+++ b/inc/class-speed-bumps-element-constraints.php
@@ -13,7 +13,7 @@ class Speed_Bumps_Element_Constraints {
 			}
 		}
 
-		return in_array( true, $paragraph_no_constrainted_elements, true );
+		return $canInsert;
 	}
 
 }

--- a/inc/class-speed-bumps-element-constraints.php
+++ b/inc/class-speed-bumps-element-constraints.php
@@ -2,12 +2,15 @@
 
 class Speed_Bumps_Element_Constraints {
 
-	public static function prev_paragraph_contains_element( $speed_bump_id, $paragraph ) {
-		$element_constraints = Speed_Bumps()->get_speed_bump_args( $speed_bump_id )[ 'element_constraints' ];
-		
-		$paragraph_no_constrainted_elements = array();
+	public static function adj_paragraph_contains_element( $canInsert, $context, $args, $alreadyInsertAd ) {
+
+		$element_constraints = $args[ 'element_constraints' ];
+
 		foreach( $element_constraints as $constraint ) {
-			$paragraph_no_constrainted_elements[] = Speed_Bumps_Element_Factory::build( ucfirst( $constraint ) )->contains( $paragraph );
+			if ( false !== stripos( $context['prev_paragraph'], '<' . $contraint ) ||
+				 false !== stripos( $context['next_paragraph'], '<' . $contraint ) ) {
+				$canInsert = false;
+			}
 		}
 
 		return in_array( true, $paragraph_no_constrainted_elements, true );

--- a/inc/class-speed-bumps-text-constraints.php
+++ b/inc/class-speed-bumps-text-constraints.php
@@ -1,14 +1,23 @@
 <?php
 
 class Speed_Bumps_Text_Constraints {
-	public static function minimum_content_length( $canInsert, $speed_bump_id, $the_content ) {
-		$minimum_length = Speed_Bumps()->get_speed_bump_args( $speed_bump_id )[ 'minimum_content_length' ];
-		$minimum_content = apply_filters( 'speed_bumps_minimum_content_length', $minimum_length); 
-		
-		if ( strlen( $the_content ) < $minimum_content ) {
+
+	public static function minimum_content_length( $canInsert, $context, $args ) {
+
+		if ( strlen( $context['the_content'] ) < $args['minimum_content'] ) {
 			$canInsert = false;
 		}
-    		return $canInsert;
+
+		return $canInsert;
+	}
+
+	public static function did_already_insert_ad( $canInsert, $context, $args, $alreadyInsertAd ) {
+
+		if ( count( $alreadyInsertAd ) > 0 ) {
+			$canInsert = false;
+		}
+
+		return $canInsert;
 	}
 
 }


### PR DESCRIPTION
Hey @noppanit -

I'm not able to explain my vision on this very well, so I tried putting a little bit of it in code to see if that makes things any clearer. This version of the `Speed_Bumps::insert_speed_bump` is closer to the logic I imagine being necessary.

This removes a lot of the specialized stuff that was going on, and reduces the entire plugin logic to one loop. After splitting the content into paragraphs, we loop through each one. We build up a context array
which should contain all the state that speed bump constraint functions should need to decide whether to block insertion. Then we run that logic through each of the speedbumps.

Does this make sense to you? I don't know that its necessarily *better* - its definitely less efficient - but it makes the whole thing much more extensible.

Like, rather than start processing in the second half of the document, loop through all the paragraphs and let a speed bump define its own filter, say a function that returns false if `$context['index'] < $context['total_paragraphs'] / 2`.

This is still a mess and I'd consider it more pseudo-code than anything. I just wanted to lay down how I thought the loop function should work. I'd like to know your thoughts & if its any clearer for you...