### PR TITLE
Adds `ad_already_inserted` and `already_inserted_here` constraints

### DIFF
--- a/inc/class-speed-bumps.php
+++ b/inc/class-speed-bumps.php
@@ -47,6 +47,7 @@ class Speed_Bumps {
 				);
 
 			foreach ( Speed_Bumps::$_speed_bumps_args as $id => $args ) {
+
 				if ( $index < $args['paragraph_offset'] ) {
 					break;
 				}
@@ -61,14 +62,15 @@ class Speed_Bumps {
 						'speed_bump_id' => $id,
 						'inserted_content' => $content_to_be_inserted,
 					);
-					unset( Speed_Bumps::$_speed_bumps_args[ $id ] );
 				}
 			}
 		}
 		return implode( PHP_EOL . PHP_EOL, $output );
 	}
 	public function register_speed_bump( $id, $args = array() ) {
+		$id = sanitize_key( $id );
 		$default = array(
+			'id' => $id,
 			'string_to_inject' => function() { return ''; },
 			'minimum_content_length' => 1200,
 			'paragraph_offset' => 0,
@@ -82,6 +84,7 @@ class Speed_Bumps {
 		Speed_Bumps::$_speed_bumps_args[ $id ] = $args;
 		add_filter( 'speed_bumps_' . $id . '_constraints', '\Speed_Bumps\Constraints\Text\Minimum_Text::minimum_content_length', 10, 4 );
 		add_filter( 'speed_bumps_' . $id . '_constraints', '\Speed_Bumps\Constraints\Content\Injection::did_already_insert_ad', 10, 4 );
+		add_filter( 'speed_bumps_' . $id . '_constraints', '\Speed_Bumps\Constraints\Content\Injection::is_ad_already_inserted_here', 10, 4 );
 		add_filter( 'speed_bumps_' . $id . '_constraints', '\Speed_Bumps\Constraints\Elements\Element_Constraints::adj_paragraph_contains_element', 10, 4 );
 	}
 

--- a/inc/constraints/content/class-injection.php
+++ b/inc/constraints/content/class-injection.php
@@ -3,24 +3,33 @@
 namespace Speed_Bumps\Constraints\Content;
 
 class Injection {
+
+	/**
+	 * Has this particular speedbump already been inserted?
+	 *
+	 */
 	public static function did_already_insert_ad( $can_insert, $context, $args, $already_inserted ) {
-		if ( self::is_ad_already_inserted_here( $context, $already_inserted ) ) {
+		if ( in_array( $args['id'], wp_list_pluck( $already_inserted, 'speed_bump_id' ) ) ) {
 			$can_insert = false;
 		}
 
 		return $can_insert;
 	}
 
-	private static function is_ad_already_inserted_here( $context, $already_inserted ) {
+	/**
+	 * Has another speed bump been inserted at this index?
+	 *
+	 */
+	public static function is_ad_already_inserted_here( $can_insert, $context, $args, $already_inserted ) {
 		$current_index = $context['index'];
+
 		foreach ( $already_inserted as $index => $element ) {
 			if ( $element['index'] === $current_index ) {
-				return true;
-				break;
+				$can_insert = false;
 			}
 		}
 
-		return false;
+		return $can_insert;
 	}
 
 }

--- a/tests/test-speed-bumps-injection-constraints.php
+++ b/tests/test-speed-bumps-injection-constraints.php
@@ -13,17 +13,42 @@ class Test_Speed_Bumps_Injection_Constraints extends WP_UnitTestCase {
 				'inserted_content' => 'content1',
 			),
 		);
-		$ad_did_inserted = \Speed_Bumps\Constraints\Content\Injection::did_already_insert_ad( true, array( 'index' => 0 ), array(), $already_inserted );
+		$ad_did_inserted = \Speed_Bumps\Constraints\Content\Injection::did_already_insert_ad( true, array( 'index' => 2 ), array( 'id' => 'speed_bump1' ), $already_inserted );
 
 		$this->assertFalse( $ad_did_inserted );
 	}
 
 	public function test_ad_not_already_inserted() {
-		$ad_did_not_insert = \Speed_Bumps\Constraints\Content\Injection::did_already_insert_ad( true, array( 'index' => 0 ), array(), array() );
+		$already_inserted = array();
+		$ad_did_not_insert = \Speed_Bumps\Constraints\Content\Injection::did_already_insert_ad( true, array( 'index' => 0 ), array( 'id' => 'speed_bump1' ), array() );
 
 		$this->assertTrue( $ad_did_not_insert );
 
 	}
 
+	public function test_ad_already_inserted_here() {
+		$already_inserted = array(
+			array(
+				'index' => 1,
+				'speed_bump_id' => 'speed_bump1',
+				'inserted_content' => 'content1',
+			),
+		);
+		$ad_did_inserted = \Speed_Bumps\Constraints\Content\Injection::is_ad_already_inserted_here( true, array( 'index' => 1 ), array( 'id' => 'apeed_bump2' ), $already_inserted );
 
+		$this->assertFalse( $ad_did_inserted );
+	}
+
+	public function test_ad_not_already_inserted_here() {
+		$already_inserted = array(
+			array(
+				'index' => 0,
+				'speed_bump_id' => 'speed_bump1',
+				'inserted_content' => 'content1',
+			),
+		);
+		$ad_did_inserted = \Speed_Bumps\Constraints\Content\Injection::is_ad_already_inserted_here( true, array( 'index' => 1 ), array( 'id' => 'apeed_bump2' ), $already_inserted );
+
+		$this->assertTrue( $ad_did_inserted );
+	}
 }


### PR DESCRIPTION
One change to the way speed bumps are registered: adds the 'id' field to
the args array so it can been checked in insertion checks.

Breaks out the insertion constraints logic into two separate functions:
has this particular speed bump already been inserted? and has another
speed bump been inserted at this location?

Updates tests to cover these two methods.