### PR TITLE
Clear Speed bump after insertion

### DIFF
--- a/inc/class-speed-bumps.php
+++ b/inc/class-speed-bumps.php
@@ -65,6 +65,8 @@ class Speed_Bumps {
 				}
 			}
 		}
+
+		Speed_Bumps::$_speed_bumps_args = array();
 		return implode( PHP_EOL . PHP_EOL, $output );
 	}
 	public function register_speed_bump( $id, $args = array() ) {

--- a/inc/class-speed-bumps.php
+++ b/inc/class-speed-bumps.php
@@ -85,9 +85,9 @@ class Speed_Bumps {
 			);
 		$args = wp_parse_args( $args, $default );
 		Speed_Bumps::$_speed_bumps_args[ $id ] = $args;
-		
+
 		$filter_id = sprintf( Speed_Bumps::$_filter_id, $id );
-		
+
 		add_filter( $filter_id, '\Speed_Bumps\Constraints\Text\Minimum_Text::content_is_long_enough_to_insert', 10, 4 );
 		add_filter( $filter_id, '\Speed_Bumps\Constraints\Content\Injection::this_speed_bump_not_already_inserted', 10, 4 );
 		add_filter( $filter_id, '\Speed_Bumps\Constraints\Content\Injection::no_speed_bump_inserted_here', 10, 4 );
@@ -105,7 +105,7 @@ class Speed_Bumps {
 	}
 
 	public static function clear_all_speed_bumps() {
-		foreach( Speed_Bumps::$_speed_bumps_args as $id => $args ) {
+		foreach ( Speed_Bumps::$_speed_bumps_args as $id => $args ) {
 			Speed_Bumps::clear_speed_bump( $id );
 		}
 	}

--- a/inc/class-speed-bumps.php
+++ b/inc/class-speed-bumps.php
@@ -4,6 +4,7 @@ namespace Speed_Bumps;
 class Speed_Bumps {
 	private static $instance;
 	private static $_speed_bumps_args = array();
+	private static $_filter_id = 'speed_bumps_%s_constraints';
 	public static function get_instance() {
 		if ( ! isset( self::$instance ) ) {
 			self::$instance = new Speed_Bumps;
@@ -84,13 +85,28 @@ class Speed_Bumps {
 			);
 		$args = wp_parse_args( $args, $default );
 		Speed_Bumps::$_speed_bumps_args[ $id ] = $args;
-		add_filter( 'speed_bumps_' . $id . '_constraints', '\Speed_Bumps\Constraints\Text\Minimum_Text::content_is_long_enough_to_insert', 10, 4 );
-		add_filter( 'speed_bumps_' . $id . '_constraints', '\Speed_Bumps\Constraints\Content\Injection::this_speed_bump_not_already_inserted', 10, 4 );
-		add_filter( 'speed_bumps_' . $id . '_constraints', '\Speed_Bumps\Constraints\Content\Injection::no_speed_bump_inserted_here', 10, 4 );
-		add_filter( 'speed_bumps_' . $id . '_constraints', '\Speed_Bumps\Constraints\Elements\Element_Constraints::adj_paragraph_not_contains_element', 10, 4 );
+		
+		$filter_id = sprintf( Speed_Bumps::$_filter_id, $id );
+		
+		add_filter( $filter_id, '\Speed_Bumps\Constraints\Text\Minimum_Text::content_is_long_enough_to_insert', 10, 4 );
+		add_filter( $filter_id, '\Speed_Bumps\Constraints\Content\Injection::this_speed_bump_not_already_inserted', 10, 4 );
+		add_filter( $filter_id, '\Speed_Bumps\Constraints\Content\Injection::no_speed_bump_inserted_here', 10, 4 );
+		add_filter( $filter_id, '\Speed_Bumps\Constraints\Elements\Element_Constraints::adj_paragraph_not_contains_element', 10, 4 );
 	}
 
 	public function get_speed_bump_args( $id ) {
 		return Speed_Bumps::$_speed_bumps_args[ $id ];
+	}
+
+	public static function clear_speed_bump( $id ) {
+		$filter_id = sprintf( Speed_Bumps::$_filter_id, $id );
+		remove_all_filters( $filter_id );
+		unset( Speed_Bumps::$_speed_bumps_args[ $id ] );
+	}
+
+	public static function clear_all_speed_bumps() {
+		foreach( Speed_Bumps::$_speed_bumps_args as $id => $args ) {
+			Speed_Bumps::clear_speed_bump( $id );
+		}
 	}
 }

--- a/tests/test-speed-bumps-integration.php
+++ b/tests/test-speed-bumps-integration.php
@@ -215,5 +215,93 @@ EOT;
 		$this->assertEquals( $expected_content, $new_content );
 	}
 
+	public function test_clear_all_speed_bumps() {
+		$content = <<<EOT
+This is the first paragraph
+
+This is the second paragraph
+
+This is the third paragraph
+
+This is the fourth paragraph
+
+This is the fifth paragraph
+EOT;
+
+		$expected_content = <<<EOT
+This is the first paragraph
+
+This is the second paragraph
+
+This is the third paragraph
+
+This is the fourth paragraph
+
+This is the fifth paragraph
+EOT;
+
+		\Speed_Bumps()->register_speed_bump( 'speed_bump1', array(
+			'string_to_inject' => function() { return 'test1'; },
+			'minimum_content_length' => 1,
+			'paragraph_offset' => 0,
+		) );
+
+		\Speed_Bumps()->register_speed_bump( 'speed_bump2', array(
+			'string_to_inject' => function() { return 'test2'; },
+			'minimum_content_length' => 1,
+			'paragraph_offset' => 0,
+		) );
+
+		\Speed_Bumps\Speed_Bumps::clear_all_speed_bumps();
+		
+		$new_content = \Speed_Bumps\Speed_Bumps::insert_speed_bumps( $content );
+		$this->assertEquals( $expected_content, $new_content );
+	}
+
+		public function test_clear_speed_bump() {
+		$content = <<<EOT
+This is the first paragraph
+
+This is the second paragraph
+
+This is the third paragraph
+
+This is the fourth paragraph
+
+This is the fifth paragraph
+EOT;
+
+		$expected_content = <<<EOT
+This is the first paragraph
+
+test1
+
+This is the second paragraph
+
+This is the third paragraph
+
+This is the fourth paragraph
+
+This is the fifth paragraph
+EOT;
+
+		\Speed_Bumps()->register_speed_bump( 'speed_bump1', array(
+			'string_to_inject' => function() { return 'test1'; },
+			'minimum_content_length' => 1,
+			'paragraph_offset' => 0,
+		) );
+
+		\Speed_Bumps()->register_speed_bump( 'speed_bump2', array(
+			'string_to_inject' => function() { return 'test2'; },
+			'minimum_content_length' => 1,
+			'paragraph_offset' => 0,
+		) );
+
+		\Speed_Bumps\Speed_Bumps::clear_speed_bump( 'speed_bump2' );
+		
+		$new_content = \Speed_Bumps\Speed_Bumps::insert_speed_bumps( $content );
+		$this->assertEquals( $expected_content, $new_content );
+	}
+
 }
 

--- a/tests/test-speed-bumps-integration.php
+++ b/tests/test-speed-bumps-integration.php
@@ -253,12 +253,12 @@ EOT;
 		) );
 
 		\Speed_Bumps\Speed_Bumps::clear_all_speed_bumps();
-		
+
 		$new_content = \Speed_Bumps\Speed_Bumps::insert_speed_bumps( $content );
 		$this->assertEquals( $expected_content, $new_content );
 	}
 
-		public function test_clear_speed_bump() {
+	public function test_clear_speed_bump() {
 		$content = <<<EOT
 This is the first paragraph
 
@@ -298,7 +298,7 @@ EOT;
 		) );
 
 		\Speed_Bumps\Speed_Bumps::clear_speed_bump( 'speed_bump2' );
-		
+
 		$new_content = \Speed_Bumps\Speed_Bumps::insert_speed_bumps( $content );
 		$this->assertEquals( $expected_content, $new_content );
 	}


### PR DESCRIPTION
I'm not sure if it's ok to do this. I think it's a good idea to discuss on GH.

https://github.com/fusioneng/fusion-theme/pull/3201#issuecomment-114178592

I have a problem with running test suits where speed bumps is added accumulatively every test. So the test failed where speed_bump is inserted where it shouldn't be. I realized that this is only for the tests but I also think that it's a good idea to clear speed bump  after all the speed bumps have been inserted. 

Thoughts @goldenapples ?