### PR TITLE
Remove static methods in `Speed_Bumps` class

### DIFF
--- a/inc/class-speed-bumps.php
+++ b/inc/class-speed-bumps.php
@@ -28,11 +28,11 @@ class Speed_Bumps {
 	**/
 	private function __wakeup(){}
 
-	private static function setup_filters() {
-		add_filter( 'speed_bumps_inject_content', '\Speed_Bumps\Speed_Bumps::insert_speed_bumps', 10 );
+	private function setup_filters() {
+		add_filter( 'speed_bumps_inject_content', array( $this, 'insert_speed_bumps' ) );
 	}
 
-	public static function insert_speed_bumps( $the_content ) {
+	public function insert_speed_bumps( $the_content ) {
 		$output = array();
 		$already_inserted = array();
 		$parts = preg_split( '/\n\s*\n/', $the_content );
@@ -47,7 +47,7 @@ class Speed_Bumps {
 				'the_content'      => $the_content,
 				);
 
-			foreach ( Speed_Bumps::get_speed_bumps() as $id => $args ) {
+			foreach ( $this->get_speed_bumps() as $id => $args ) {
 
 				if ( $index < $args['paragraph_offset'] ) {
 					break;
@@ -83,9 +83,9 @@ class Speed_Bumps {
 				),
 			);
 		$args = wp_parse_args( $args, $default );
-		Speed_Bumps::$speed_bumps[ $id ] = $args;
+		self::$speed_bumps[ $id ] = $args;
 
-		$filter_id = sprintf( Speed_Bumps::$filter_id, $id );
+		$filter_id = sprintf( self::$filter_id, $id );
 
 		add_filter( $filter_id, '\Speed_Bumps\Constraints\Text\Minimum_Text::content_is_long_enough_to_insert', 10, 4 );
 		add_filter( $filter_id, '\Speed_Bumps\Constraints\Content\Injection::this_speed_bump_not_already_inserted', 10, 4 );
@@ -94,22 +94,22 @@ class Speed_Bumps {
 	}
 
 	public function get_speed_bumps() {
-		return Speed_Bumps::$speed_bumps;
+		return self::$speed_bumps;
 	}
 
 	public function get_speed_bump( $id ) {
-		return Speed_Bumps::$speed_bumps[ $id ];
+		return self::$speed_bumps[ $id ];
 	}
 
-	public static function clear_speed_bump( $id ) {
-		$filter_id = sprintf( Speed_Bumps::$filter_id, $id );
+	public function clear_speed_bump( $id ) {
+		$filter_id = sprintf( self::$filter_id, $id );
 		remove_all_filters( $filter_id );
-		unset( Speed_Bumps::$speed_bumps[ $id ] );
+		unset( self::$speed_bumps[ $id ] );
 	}
 
-	public static function clear_all_speed_bumps() {
-		foreach ( Speed_Bumps::get_speed_bumps() as $id => $args ) {
-			Speed_Bumps::clear_speed_bump( $id );
+	public function clear_all_speed_bumps() {
+		foreach ( $this->get_speed_bumps() as $id => $args ) {
+			$this->clear_speed_bump( $id );
 		}
 	}
 }

--- a/tests/test-speed-bumps-integration.php
+++ b/tests/test-speed-bumps-integration.php
@@ -25,7 +25,7 @@ EOT;
 			'paragraph_offset' => 0,
 		) );
 
-		$newContent = \Speed_Bumps\Speed_Bumps::insert_speed_bumps( $content );
+		$newContent = Speed_Bumps()->insert_speed_bumps( $content );
 		$this->assertEquals( $expected_content, $newContent );
 
 	}
@@ -46,7 +46,7 @@ EOT;
 			'string_to_inject' => function() { return '<div id="polar-ad"></div>'; },
 		) );
 
-		$newContent = \Speed_Bumps\Speed_Bumps::insert_speed_bumps( $content );
+		$newContent = Speed_Bumps()->insert_speed_bumps( $content );
 		$this->assertEquals( $expectedContent, $newContent );
 	}
 
@@ -57,7 +57,7 @@ EOT;
 			'string_to_inject' => function() { return '<div id="polar-ad"></div>'; },
 		) );
 
-		$newContent = \Speed_Bumps\Speed_Bumps::insert_speed_bumps( $content );
+		$newContent = Speed_Bumps()->insert_speed_bumps( $content );
 		$this->assertNotContains( '<div id="polar-ad"></div>', $newContent );
 
 	}
@@ -85,7 +85,7 @@ EOT;
 			'paragraph_offset' => 1,
 		) );
 
-		$newContent = \Speed_Bumps\Speed_Bumps::insert_speed_bumps( $content );
+		$newContent = Speed_Bumps()->insert_speed_bumps( $content );
 		$this->assertEquals( $expectedContent, $newContent );
 
 	}
@@ -115,7 +115,7 @@ EOT;
 			'paragraph_offset' => 1,
 		) );
 
-		$newContent = \Speed_Bumps\Speed_Bumps::insert_speed_bumps( $content );
+		$newContent = Speed_Bumps()->insert_speed_bumps( $content );
 		$this->assertEquals( $expectedContent, $newContent );
 
 	}
@@ -166,7 +166,7 @@ EOT;
 			'paragraph_offset' => 2,
 		) );
 
-		$newContent = \Speed_Bumps\Speed_Bumps::insert_speed_bumps( $content );
+		$newContent = Speed_Bumps()->insert_speed_bumps( $content );
 		$this->assertEquals( $expectedContent, $newContent );
 
 	}
@@ -211,7 +211,7 @@ EOT;
 			'paragraph_offset' => 0,
 		) );
 
-		$new_content = \Speed_Bumps\Speed_Bumps::insert_speed_bumps( $content );
+		$new_content = Speed_Bumps()->insert_speed_bumps( $content );
 		$this->assertEquals( $expected_content, $new_content );
 	}
 
@@ -252,9 +252,9 @@ EOT;
 			'paragraph_offset' => 0,
 		) );
 
-		\Speed_Bumps\Speed_Bumps::clear_all_speed_bumps();
+		Speed_Bumps()->clear_all_speed_bumps();
 
-		$new_content = \Speed_Bumps\Speed_Bumps::insert_speed_bumps( $content );
+		$new_content = Speed_Bumps()->insert_speed_bumps( $content );
 		$this->assertEquals( $expected_content, $new_content );
 	}
 
@@ -297,9 +297,9 @@ EOT;
 			'paragraph_offset' => 0,
 		) );
 
-		\Speed_Bumps\Speed_Bumps::clear_speed_bump( 'speed_bump2' );
+		Speed_Bumps()->clear_speed_bump( 'speed_bump2' );
 
-		$new_content = \Speed_Bumps\Speed_Bumps::insert_speed_bumps( $content );
+		$new_content = Speed_Bumps()->insert_speed_bumps( $content );
 		$this->assertEquals( $expected_content, $new_content );
 	}
 

--- a/tests/test-speed-bumps-registration.php
+++ b/tests/test-speed-bumps-registration.php
@@ -5,7 +5,7 @@ class Test_Speed_Bumps_Registration extends WP_UnitTestCase {
 	private $speed_bump;
 	public function setUp() {
 		parent::setUp();
-		$this->speed_bump = \Speed_Bumps\Speed_Bumps::get_instance();
+		$this->speed_bumps = \Speed_Bumps\Speed_Bumps::get_instance();
 	}
 
 	public function test_has_filter_speed_bumps_inject_content() {
@@ -14,15 +14,15 @@ class Test_Speed_Bumps_Registration extends WP_UnitTestCase {
 	}
 
 	public function test_has_filter_speed_bumps_paragraph_constraints() {
-		$this->speed_bump->register_speed_bump( 'id' );
+		$this->speed_bumps->register_speed_bump( 'id' );
 
 		$filter_exists = has_filter( 'speed_bumps_id_constraints' );
 		$this->assertTrue( $filter_exists );
 	}
 
 	public function test_speed_bump_registration_default_arguments() {
-		$this->speed_bump->register_speed_bump( 'speed_bump1' );
-		$speed_bump1_args = \Speed_Bumps()->get_speed_bump_args( 'speed_bump1' );
+		$this->speed_bumps->register_speed_bump( 'speed_bump1' );
+		$speed_bump1_args = $this->speed_bumps->get_speed_bump( 'speed_bump1' );
 
 		$this->assertEquals( $speed_bump1_args['string_to_inject'], function() { return ''; } );
 		$this->assertEquals( $speed_bump1_args['minimum_content_length'], 1200 );
@@ -31,13 +31,13 @@ class Test_Speed_Bumps_Registration extends WP_UnitTestCase {
 	}
 
 	public function test_speed_bump_registration_with_different_arguments() {
-		$this->speed_bump->register_speed_bump( 'speed_bump1' );
-		$speed_bump1_args = \Speed_Bumps()->get_speed_bump_args( 'speed_bump1' );
+		$this->speed_bumps->register_speed_bump( 'speed_bump1' );
+		$speed_bump1_args = $this->speed_bumps->get_speed_bump( 'speed_bump1' );
 
 		$this->assertEquals( $speed_bump1_args['minimum_content_length'], 1200 );
 
-		$this->speed_bump->register_speed_bump( 'speed_bump2', array( 'minimum_content_length' => 10 ) );
-		$speed_bump2_args = \Speed_Bumps()->get_speed_bump_args( 'speed_bump2' );
+		$this->speed_bumps->register_speed_bump( 'speed_bump2', array( 'minimum_content_length' => 10 ) );
+		$speed_bump2_args = $this->speed_bumps->get_speed_bump( 'speed_bump2' );
 		$this->assertEquals( $speed_bump2_args['minimum_content_length'], 10 );
 	}
 


### PR DESCRIPTION
A couple new public non-static methods were introduced in #27. I'm
afraid that a mix of static and non-static methods in a class will make
for a really confusing API. This PR changes all of the public methods in
the Speed_Bumps class to non-static instance methods.