### PR TITLE
Add "priority" argument to speed bump registration

### DIFF
--- a/speed-bumps.php
+++ b/speed-bumps.php
@@ -132,7 +132,7 @@ class Speed_Bumps {
 		return implode( PHP_EOL . PHP_EOL, $output );
 	}
 
-	public function register_speed_bump( $id, $args = array() ) {
+	public function register_speed_bump( $id, $args = array(), $priority = 10 ) {
 		$id = sanitize_key( $id );
 		$default = array(
 			'id' => $id,
@@ -147,7 +147,18 @@ class Speed_Bumps {
 			'minimum_space_from_other_inserts' => 1,
 			);
 		$args = wp_parse_args( $args, $default );
+		$args['priority'] = $priority;
+
 		self::$speed_bumps[ $id ] = $args;
+
+		uasort( self::$speed_bumps,
+			function( $a, $b ) {
+				if ( $a['priority'] == $b['priority'] ) {
+					return 0;
+				}
+				return $a['priority'] < $b['priority'] ? -1 : 1;
+			}
+		);
 
 		$filter_id = sprintf( self::$filter_id, $id );
 
@@ -159,6 +170,7 @@ class Speed_Bumps {
 		add_filter( $filter_id, '\Speed_Bumps\Constraints\Content\Injection::minimum_space_from_other_inserts_paragraphs', 10, 4 );
 		add_filter( $filter_id, '\Speed_Bumps\Constraints\Content\Injection::minimum_space_from_other_inserts_words', 10, 4 );
 		add_filter( $filter_id, '\Speed_Bumps\Constraints\Elements\Element_Constraints::adj_paragraph_not_contains_element', 10, 4 );
+
 	}
 
 	public function get_speed_bumps() {

--- a/tests/test-speed-bumps-registration.php
+++ b/tests/test-speed-bumps-registration.php
@@ -20,6 +20,14 @@ class Test_Speed_Bumps_Registration extends WP_UnitTestCase {
 		$this->assertTrue( $filter_exists );
 	}
 
+	public function test_registration_priority() {
+		$this->speed_bumps->clear_all_speed_bumps();
+		$this->speed_bumps->register_speed_bump( 'id10' );
+		$this->speed_bumps->register_speed_bump( 'id5', null, 5 );
+		$this->speed_bumps->register_speed_bump( 'id100', null, 100 );
+		$this->assertEquals( array( 'id5', 'id10', 'id100' ), array_keys( Speed_Bumps()->get_speed_bumps() ) );
+	}
+
 	public function test_speed_bump_registration_default_arguments() {
 		$this->speed_bumps->register_speed_bump( 'speed_bump1' );
 		$speed_bump1_args = $this->speed_bumps->get_speed_bump( 'speed_bump1' );


### PR DESCRIPTION
See #40.

Adds a priority argument on registering speed bumps. Sorts registered
speed bumps by priority, so that those with the lowest priority get
processed and inserted first, all other things being equal.

Note that insertion points are still processed paragraph by paragraph,
so that a speed bump with priority 100 but paragraph offset 2 will still
get inserted before a speed bump with priority 1 and paragraph offset 3.