### PR TITLE
Remove check of index against "from_start" arg

### DIFF
--- a/speed-bumps.php
+++ b/speed-bumps.php
@@ -125,10 +125,6 @@ class Speed_Bumps {
 
 			foreach ( $this->get_speed_bumps() as $id => $args ) {
 
-				if ( $index < $args['from_start'] ) {
-					break;
-				}
-
 				if ( apply_filters( 'speed_bumps_'. $id . '_constraints', true, $context, $args, $already_inserted ) ) {
 
 					$content_to_be_inserted = call_user_func( $args['string_to_inject'], $context, $already_inserted );

--- a/tests/test-speed-bumps-integration.php
+++ b/tests/test-speed-bumps-integration.php
@@ -24,7 +24,9 @@ class Test_Speed_Bumps_Integration extends WP_UnitTestCase {
 
 		\Speed_Bumps()->register_speed_bump( 'speed_bump1', array(
 			'string_to_inject' => function() { return '<div id="polar-ad"></div>'; },
-			'from_start' => 2,
+			'from_start' => array(
+				'paragraphs' => 2,
+			),
 			'from_end' => false,
 			'from_element' => false,
 			'minimum_content_length' => array( 'characters' => 1200 ),


### PR DESCRIPTION
This was left in from a bad merge in #38, with the result that trying to define "from_start" as an array will almost always result in a speed bump never being inserted, because of trying to compare an integer to an array:

```
wp> $a = array('paragraphs' => 3);
array(1) {
  'paragraphs' =>
  int(3)
}
wp> 2 < $a
bool(true)
wp> 4 < $a
bool(true)
wp> 12 < $a
bool(true)
```

This constraint is now being handled in '\Speed_Bumps\Constraints\Text\Minimum_Text::meets_minimum_distance_from_start', so there's no need for the special check in the loop anymore.