### PR TITLE
Use `WP_Embed::shortcode()` to ensure we hit cache

### DIFF
--- a/inc/constraints/elements/class-oembed.php
+++ b/inc/constraints/elements/class-oembed.php
@@ -6,7 +6,7 @@ class Oembed extends Constraint_Abstract {
 	public function paragraph_not_contains_element( $paragraph ) {
 		preg_match_all( '|^\s*(https?://[^\s"]+)\s*$|im', $paragraph, $matches );
 		foreach ( $matches[1] as $match ) {
-			if ( wp_oembed_get( $match ) ) {
+			if ( $GLOBALS['wp_embed']->shortcode( array(), $match ) ) {
 				return false;
 			}
 		}


### PR DESCRIPTION
This also means we will hit expected filters

Related #37 