### PR TITLE
Update tests and slice method to fix off-by-one error

### DIFF
--- a/inc/constraints/text/class-minimum-text.php
+++ b/inc/constraints/text/class-minimum-text.php
@@ -69,7 +69,7 @@ class Minimum_Text {
 		}
 
 		if ( is_array( $args['from_start'] ) ) {
-			$from_start = array_slice( $context['parts'], 0, $context['index'] );
+			$from_start = array_slice( $context['parts'], 0, $context['index'] + 1 );
 
 			foreach ( array( 'paragraphs', 'words', 'characters' ) as $unit ) {
 				if ( isset( $args['from_start'][ $unit ] ) &&
@@ -104,7 +104,7 @@ class Minimum_Text {
 		}
 
 		if ( is_array( $args['from_end'] ) ) {
-			$from_end = array_slice( $context['parts'], $context['index'] );
+			$from_end = array_slice( $context['parts'], $context['index'] + 1 );
 
 			foreach ( array( 'paragraphs', 'words', 'characters' ) as $unit ) {
 				if ( isset( $args['from_end'][ $unit ] ) &&

--- a/tests/constraints/test-speed-bumps-text-constraints.php
+++ b/tests/constraints/test-speed-bumps-text-constraints.php
@@ -72,13 +72,13 @@ than 1200Something longer than 1200';
 			'the_content' => $this->content,
 			'parts' => Text::split_paragraphs( $this->content ),
 			'total_paragraphs' => 5,
-			'index' => 2,
+			'index' => 1,
 		);
 
 		$okToInsert = Minimum_Text::meets_minimum_distance_from_start( true, $context, $args, array() );
 		$this->assertTrue( $okToInsert );
 
-		$context['index'] = 1;
+		$context['index'] = 0;
 		$okToInsert = Minimum_Text::meets_minimum_distance_from_start( true, $context, $args, array() );
 		$this->assertFalse( $okToInsert );
 	}
@@ -91,13 +91,13 @@ than 1200Something longer than 1200';
 			'the_content' => $this->content,
 			'parts' => Text::split_paragraphs( $this->content ),
 			'total_paragraphs' => 5,
-			'index' => 4,
+			'index' => 1,
 		);
 
 		$okToInsert = Minimum_Text::meets_minimum_distance_from_start( true, $context, $args, array() );
 		$this->assertTrue( $okToInsert );
 
-		$context['index'] = 1;
+		$context['index'] = 0;
 		$okToInsert = Minimum_Text::meets_minimum_distance_from_start( true, $context, $args, array() );
 		$this->assertFalse( $okToInsert );
 	}
@@ -110,13 +110,13 @@ than 1200Something longer than 1200';
 			'the_content' => $this->content,
 			'parts' => Text::split_paragraphs( $this->content ),
 			'total_paragraphs' => 5,
-			'index' => 4,
+			'index' => 1,
 		);
 
 		$okToInsert = Minimum_Text::meets_minimum_distance_from_start( true, $context, $args, array() );
 		$this->assertTrue( $okToInsert );
 
-		$context['index'] = 1;
+		$context['index'] = 0;
 		$okToInsert = Minimum_Text::meets_minimum_distance_from_start( true, $context, $args, array() );
 		$this->assertFalse( $okToInsert );
 	}

--- a/tests/test-speed-bumps-integration.php
+++ b/tests/test-speed-bumps-integration.php
@@ -33,7 +33,7 @@ class Test_Speed_Bumps_Integration extends WP_UnitTestCase {
 		) );
 
 		$new_content = Speed_Bumps()->insert_speed_bumps( $content );
-		$this->assertSpeedBumpAtParagraph( $new_content, 4, '<div id="polar-ad"></div>' );
+		$this->assertSpeedBumpAtParagraph( $new_content, 3, '<div id="polar-ad"></div>' );
 	}
 
 	public function test_speed_bump_not_inserted_with_content_less_than_1200() {


### PR DESCRIPTION
`array_slice( $parts, 0, 3 )` actually returns 4 paragraphs. So the
default arguments of 3 paragraphs from start were actually not inserting
till a minimum of 4 paragraphs from start...

#60