### PR TITLE
Use WP_oEmbed->get_provider for faster matching of oembeds

### DIFF
--- a/inc/constraints/elements/class-oembed.php
+++ b/inc/constraints/elements/class-oembed.php
@@ -4,9 +4,11 @@ namespace Speed_Bumps\Constraints\Elements;
 class Oembed extends Constraint_Abstract {
 
 	public function paragraph_not_contains_element( $paragraph ) {
+		require_once ABSPATH . WPINC . '/class-oembed.php';
+		$wp_oembed = _wp_oembed_get_object();
 		preg_match_all( '|^\s*(https?://[^\s"]+)\s*$|im', $paragraph, $matches );
 		foreach ( $matches[1] as $match ) {
-			if ( $GLOBALS['wp_embed']->shortcode( array(), $match ) ) {
+			if ( $wp_oembed->get_provider( $match, array( 'discover' => false ) ) ) {
 				return false;
 			}
 		}


### PR DESCRIPTION
This method only validates the url against the regex of defined oembeds,
and doesn't actually follow the callback to get the markup since that's
not needed here.

#62