### PR TITLE
Prevent speed bumps from inserting inside blockquotes

### DIFF
--- a/inc/constraints/elements/class-blockquote.php
+++ b/inc/constraints/elements/class-blockquote.php
@@ -9,4 +9,17 @@ class Blockquote extends Constraint_Abstract {
 
 		return true;
 	}
+
+	public function not_inside_unclosed_element( $before, $after ) {
+		if ( false === stripos( $before, 'blockquote' ) ) {
+			return true;
+		}
+		preg_match_all( '#<\s*blockquote[^>]*>#', $before, $opening_tags, PREG_SET_ORDER );
+		preg_match_all( '#<\s*/\s*blockquote[^>]*>#', $before, $closing_tags, PREG_SET_ORDER );
+		if ( count( $opening_tags ) <= count( $closing_tags ) ) {
+			return true;
+		}
+
+		return false;
+	}
 }

--- a/inc/constraints/elements/class-dummy.php
+++ b/inc/constraints/elements/class-dummy.php
@@ -5,4 +5,8 @@ class Dummy extends Constraint_Abstract {
 	public function paragraph_not_contains_element( $paragraph ) {
 		return false;
 	}
+
+	public function not_inside_unclosed_element( $before, $after ) {
+		return false;
+	}
 }

--- a/inc/constraints/elements/class-element-constraints.php
+++ b/inc/constraints/elements/class-element-constraints.php
@@ -89,4 +89,38 @@ class Element_Constraints {
 		return $can_insert;
 	}
 
+	/**
+	 * If the element defines a method of ensuring that the current point is
+	 * not inside an unclosed element (like the middle of a blockquote), call
+	 * it, to make sure this is an acceptable insertion point.
+	 *
+	 */
+	public static function not_inside_unclosed_element( $can_insert, $context, $args, $already_inserted ) {
+
+		if ( ! is_array( $args['from_element'] ) ) {
+			return $can_insert;
+		}
+
+		$defaults = array_flip( array( 'paragraphs', 'words', 'characters' ) );
+		$from_element = array_diff_key( $args['from_element'], $defaults );
+
+		if ( ! empty( $from_element ) ) {
+			foreach ( $from_element as $key => $val ) {
+				if ( is_int( $key ) ) {
+					$element_to_check = Factory::build( ucfirst( $val ) );
+				} else {
+					$element_to_check = Factory::build( ucfirst( $key ) );
+				}
+
+				if ( method_exists( $element_to_check, 'not_inside_unclosed_element' ) &&
+						! $element_to_check->not_inside_unclosed_element( Text::content_before( $context ), Text::content_after( $context ) ) ) {
+					$can_insert = false;
+					continue;
+				}
+			}
+		}
+
+		return $can_insert;
+	}
+
 }

--- a/inc/utils/class-text.php
+++ b/inc/utils/class-text.php
@@ -45,6 +45,26 @@ class Text {
 	}
 
 	/**
+	 * Get the content before the current index.
+	 *
+	 * @param array $context Context array
+	 * @return string
+	 */
+	public static function content_before( $context ) {
+		return implode( "\n\n", self::content_between_points( $context['parts'], 0, $context['index'] ) );
+	}
+
+	/**
+	 * Get the content after the current index.
+	 *
+	 * @param array $context Context array
+	 * @return string
+	 */
+	public static function content_after( $context ) {
+		return implode( "\n\n", self::content_between_points( $context['parts'], $context['index'], $context['total_paragraphs'] ) );
+	}
+
+	/**
 	 * Get the content within a certain distance of a given index
 	 *
 	 * Given two indexes, return an array of paragraphs between those two indexes.

--- a/speed-bumps.php
+++ b/speed-bumps.php
@@ -225,6 +225,7 @@ class Speed_Bumps {
 		add_filter( $filter_id, '\Speed_Bumps\Constraints\Content\Injection::less_than_maximum_number_of_inserts', 10, 4 );
 		add_filter( $filter_id, '\Speed_Bumps\Constraints\Content\Injection::meets_minimum_distance_from_other_inserts', 10, 4 );
 		add_filter( $filter_id, '\Speed_Bumps\Constraints\Elements\Element_Constraints::meets_minimum_distance_from_elements', 10, 4 );
+		add_filter( $filter_id, '\Speed_Bumps\Constraints\Elements\Element_Constraints::not_inside_unclosed_element', 10, 4 );
 	}
 
 	public function get_speed_bumps() {


### PR DESCRIPTION
Adds another optional method to element constraints, `not_inside_unclosed_element`, which can be used to ensure that the insertion point is not inside an unclosed tag.