### PR TITLE
Remove speed bumps after using them max times

### DIFF
--- a/inc/constraints/content/class-injection.php
+++ b/inc/constraints/content/class-injection.php
@@ -36,6 +36,12 @@ class Injection {
 		);
 
 		if ( count( $this_speed_bump_insertions ) >= $args['maximum_inserts'] ) {
+			global $_wp_filters_backed_up, $wp_filter;
+			$current_filter = current_filter();
+			$_wp_filters_backed_up[ $current_filter ] = $wp_filter[ $current_filter ];
+			remove_all_filters( $current_filter );
+			add_filter( $current_filter, '__return_false' );
+
 			$can_insert = false;
 		}
 

--- a/inc/constraints/content/class-injection.php
+++ b/inc/constraints/content/class-injection.php
@@ -38,9 +38,11 @@ class Injection {
 
 		if ( count( $this_speed_bump_insertions ) >= $args['maximum_inserts'] ) {
 			$current_filter = current_filter();
-			$_wp_filters_backed_up[ $current_filter ] = $wp_filter[ $current_filter ];
-			remove_all_filters( $current_filter );
-			add_filter( $current_filter, '__return_false' );
+			if ( $current_filter && in_array( $current_filter, Speed_Bumps()->get_speed_bumps_filters() ) ) {
+				$_wp_filters_backed_up[ $current_filter ] = $wp_filter[ $current_filter ];
+				remove_all_filters( $current_filter );
+				add_filter( $current_filter, '__return_false' );
+			}
 
 			$can_insert = false;
 		}

--- a/inc/constraints/content/class-injection.php
+++ b/inc/constraints/content/class-injection.php
@@ -30,13 +30,13 @@ class Injection {
 	 * by the 'maximum_inserts' argument on speed bump registration.
 	 */
 	public static function less_than_maximum_number_of_inserts( $can_insert, $context, $args, $already_inserted ) {
+		global $_wp_filters_backed_up, $wp_filter;
 
 		$this_speed_bump_insertions = array_filter( $already_inserted,
 			function( $insertion ) use ( $args ) { return $insertion['speed_bump_id'] === $args['id']; }
 		);
 
 		if ( count( $this_speed_bump_insertions ) >= $args['maximum_inserts'] ) {
-			global $_wp_filters_backed_up, $wp_filter;
 			$current_filter = current_filter();
 			$_wp_filters_backed_up[ $current_filter ] = $wp_filter[ $current_filter ];
 			remove_all_filters( $current_filter );

--- a/speed-bumps.php
+++ b/speed-bumps.php
@@ -141,14 +141,7 @@ class Speed_Bumps {
 			}
 		}
 
-		// Restore any filters which were removed by `Insertion::less_than_maximum_number_of_inserts`
-		if ( is_array( $_wp_filters_backed_up ) ) {
-			foreach ( $_wp_filters_backed_up as $hook => $filters ) {
-				$wp_filter[ $hook ] = $filters;
-			}
-			$_wp_filters_backed_up = array();
-		}
-
+		$this->reset_all_speed_bumps();
 		return implode( PHP_EOL . PHP_EOL, $output );
 	}
 
@@ -241,6 +234,17 @@ class Speed_Bumps {
 		return self::$speed_bumps;
 	}
 
+	public function get_speed_bumps_filters() {
+		$speed_bumps = $this->get_speed_bumps();
+		$filter_pattern = self::$filter_id;
+
+		return array_map(
+			function( $id ) use ( $filter_pattern ) {
+				return sprintf( $filter_pattern, $id );
+			}, array_keys( $speed_bumps )
+		);
+	}
+
 	public function get_speed_bump( $id ) {
 		return self::$speed_bumps[ $id ];
 	}
@@ -254,6 +258,21 @@ class Speed_Bumps {
 	public function clear_all_speed_bumps() {
 		foreach ( $this->get_speed_bumps() as $id => $args ) {
 			$this->clear_speed_bump( $id );
+		}
+	}
+
+	/**
+	 * Restore any filters which were removed by
+	 * `Insertion::less_than_maximum_number_of_inserts`
+	 */
+	public function reset_all_speed_bumps() {
+		global $_wp_filters_backed_up, $wp_filter;
+
+		if ( is_array( $_wp_filters_backed_up ) ) {
+			foreach ( $_wp_filters_backed_up as $hook => $filters ) {
+				$wp_filter[ $hook ] = $filters;
+			}
+			$_wp_filters_backed_up = array();
 		}
 	}
 }

--- a/speed-bumps.php
+++ b/speed-bumps.php
@@ -109,6 +109,7 @@ class Speed_Bumps {
 	 */
 	public function insert_speed_bumps( $the_content ) {
 		global $_wp_filters_backed_up, $wp_filter;
+		$_wp_filters_backed_up = array();
 		$output = array();
 		$already_inserted = array();
 		$parts = Text::split_paragraphs( $the_content );

--- a/speed-bumps.php
+++ b/speed-bumps.php
@@ -108,6 +108,7 @@ class Speed_Bumps {
 	 * @return string The text with all registered speed bumps inserted at appropriate locations if possible.
 	 */
 	public function insert_speed_bumps( $the_content ) {
+		global $_wp_filters_backed_up, $wp_filter;
 		$output = array();
 		$already_inserted = array();
 		$parts = Text::split_paragraphs( $the_content );
@@ -137,6 +138,14 @@ class Speed_Bumps {
 					);
 				}
 			}
+		}
+
+		// Restore any filters which were removed by `Insertion::less_than_maximum_number_of_inserts`
+		if ( is_array( $_wp_filters_backed_up ) ) {
+			foreach ( $_wp_filters_backed_up as $hook => $filters ) {
+				$wp_filter[ $hook ] = $filters;
+			}
+			$_wp_filters_backed_up = array();
 		}
 
 		return implode( PHP_EOL . PHP_EOL, $output );

--- a/tests/test-speed-bumps-registration.php
+++ b/tests/test-speed-bumps-registration.php
@@ -39,6 +39,43 @@ class Test_Speed_Bumps_Registration extends WP_UnitTestCase {
 		$this->speed_bumps->register_speed_bump( 'speed_bump2', array( 'minimum_content_length' => array( 'paragraphs' => 10 ) ) );
 		$speed_bump2_args = $this->speed_bumps->get_speed_bump( 'speed_bump2' );
 		$this->assertEquals( $speed_bump2_args['minimum_content_length'], array( 'paragraphs' => 10 ) );
+
 	}
 
+	public function test_get_speed_bumps_filters() {
+		Speed_Bumps()->clear_all_speed_bumps();
+		$this->speed_bumps->register_speed_bump( '1' );
+		$this->speed_bumps->register_speed_bump( '2' );
+		$this->assertEquals( array( 'speed_bumps_1_constraints', 'speed_bumps_2_constraints' ), Speed_Bumps()->get_speed_bumps_filters() );
+	}
+
+	public function test_wp_backed_up_filters() {
+		$this->speed_bumps->register_speed_bump( '1' );
+		$context = array(
+			'index'            => 1,
+			'prev_paragraph'   => '',
+			'next_paragraph'   => '',
+			'total_paragraphs' => 5,
+			'the_content'      => '',
+			'parts'            => array(),
+		);
+		$args = Speed_Bumps()->get_speed_bump( '1' );
+		$already_inserted = array(
+			array(
+				'index' => 0,
+				'speed_bump_id' => '1',
+				'inserted_content' => '',
+			)
+		);
+		apply_filters( 'speed_bumps_1_constraints', true, $context, $args, $already_inserted );
+
+		global $_wp_filters_backed_up, $wp_filter;
+		$this->assertNotEmpty( $_wp_filters_backed_up[ 'speed_bumps_1_constraints' ] );
+		$this->assertCount( 1, $wp_filter['speed_bumps_1_constraints'][10] );
+		$this->assertNotEmpty( $wp_filter['speed_bumps_1_constraints'][10]['__return_false'] );
+
+		Speed_Bumps()->reset_all_speed_bumps();
+		$this->assertEmpty( $_wp_filters_backed_up );
+		$this->assertCount( 6, $wp_filter['speed_bumps_1_constraints'][10] );
+	}
 }

--- a/tests/test-speed-bumps-registration.php
+++ b/tests/test-speed-bumps-registration.php
@@ -65,12 +65,12 @@ class Test_Speed_Bumps_Registration extends WP_UnitTestCase {
 				'index' => 0,
 				'speed_bump_id' => '1',
 				'inserted_content' => '',
-			)
+			),
 		);
 		apply_filters( 'speed_bumps_1_constraints', true, $context, $args, $already_inserted );
 
 		global $_wp_filters_backed_up, $wp_filter;
-		$this->assertNotEmpty( $_wp_filters_backed_up[ 'speed_bumps_1_constraints' ] );
+		$this->assertNotEmpty( $_wp_filters_backed_up['speed_bumps_1_constraints'] );
 		$this->assertCount( 1, $wp_filter['speed_bumps_1_constraints'][10] );
 		$this->assertNotEmpty( $wp_filter['speed_bumps_1_constraints'][10]['__return_false'] );
 


### PR DESCRIPTION
After a speed bump is inserted its maximum number of times, remove all filters related to it. Backs those filters up in a global, `$_wp_filters_backed_up`, so that they can be restored later.

See #73