### PR TITLE
Use strict mode for checking `in_array()`

### DIFF
--- a/inc/constraints/content/class-injection.php
+++ b/inc/constraints/content/class-injection.php
@@ -38,7 +38,7 @@ class Injection {
 
 		if ( count( $this_speed_bump_insertions ) >= $args['maximum_inserts'] ) {
 			$current_filter = current_filter();
-			if ( $current_filter && in_array( $current_filter, Speed_Bumps()->get_speed_bumps_filters() ) ) {
+			if ( $current_filter && in_array( $current_filter, Speed_Bumps()->get_speed_bumps_filters(), true ) ) {
 				$_wp_filters_backed_up[ $current_filter ] = $wp_filter[ $current_filter ];
 				remove_all_filters( $current_filter );
 				add_filter( $current_filter, '__return_false' );


### PR DESCRIPTION
Avoids PHPCS warnings. See #77.