### PR TITLE
Add "Last ditch fallback" option

### DIFF
--- a/speed-bumps.php
+++ b/speed-bumps.php
@@ -150,7 +150,7 @@ class Speed_Bumps {
 			if ( ! empty( $args['last_ditch_fallback'] ) ) {
 
 				if ( is_callable( $args['last_ditch_fallback'] ) ) {
-					$insert_last_ditch_speed_bump = call_user_func( $args['last_ditch_fallback'], $context, $already_inserted );
+					$can_insert = call_user_func( $args['last_ditch_fallback'], $context, $already_inserted );
 				} else {
 					$inserted = array_filter( $already_inserted, function( $insert ) use ( $id ) { return $insert['speed_bump_id'] === $id; } );
 					$can_insert = ( count( $inserted ) < $args['minimum_inserts'] );

--- a/speed-bumps.php
+++ b/speed-bumps.php
@@ -195,7 +195,10 @@ class Speed_Bumps {
 			// Maximum number of times this can be inserted in a post
 			'maximum_inserts' => 1,
 
-			// Minimum times this should be inserted, if 'last_ditch_rules' is true
+			// Minimum times this should be inserted, if 'last_ditch_fallback' is true
+			// (NOTE: this doesn't mean the speed bump will necessarily be inserted this
+			// number of times; but if it has been inserted fewer times than this at the end
+			// of the content, a "last ditch" insertion will be processed.)
 			'minimum_inserts' => 1,
 			'last_ditch_fallback' => false,
 

--- a/speed-bumps.php
+++ b/speed-bumps.php
@@ -127,7 +127,7 @@ class Speed_Bumps {
 
 			foreach ( $this->get_speed_bumps() as $id => $args ) {
 
-				if ( apply_filters( 'speed_bumps_'. $id . '_constraints', true, $context, $args, $already_inserted ) ) {
+				if ( apply_filters( 'speed_bumps_' . $id . '_constraints', true, $context, $args, $already_inserted ) ) {
 
 					$content_to_be_inserted = call_user_func( $args['string_to_inject'], $context, $already_inserted );
 
@@ -169,7 +169,6 @@ class Speed_Bumps {
 				}
 			}
 		}
-
 
 		$this->reset_all_speed_bumps();
 		return implode( PHP_EOL . PHP_EOL, $output );

--- a/tests/constraints/test-speed-bumps-element-constraints.php
+++ b/tests/constraints/test-speed-bumps-element-constraints.php
@@ -33,12 +33,12 @@ than 1200Something longer than 1200';
 			),
 		);
 
-		$okToInsert = Element_Constraints::meets_minimum_distance_from_elements( true, $context, $args, array() );
-		$this->assertFalse( $okToInsert );
+		$ok_to_insert = Element_Constraints::meets_minimum_distance_from_elements( true, $context, $args, array() );
+		$this->assertFalse( $ok_to_insert );
 
 		$context['index'] = 3;
-		$okToInsert = Element_Constraints::meets_minimum_distance_from_elements( true, $context, $args, array() );
-		$this->assertTrue( $okToInsert );
+		$ok_to_insert = Element_Constraints::meets_minimum_distance_from_elements( true, $context, $args, array() );
+		$this->assertTrue( $ok_to_insert );
 
 		$args['from_element'] = array(
 			'paragraphs' => 2,
@@ -46,12 +46,12 @@ than 1200Something longer than 1200';
 				'paragraphs' => 4,
 			),
 		);
-		$okToInsert = Element_Constraints::meets_minimum_distance_from_elements( true, $context, $args, array() );
-		$this->assertFalse( $okToInsert );
+		$ok_to_insert = Element_Constraints::meets_minimum_distance_from_elements( true, $context, $args, array() );
+		$this->assertFalse( $ok_to_insert );
 
 		$args['from_element']['blockquote'] = array( 'paragraphs' => 1 );
-		$okToInsert = Element_Constraints::meets_minimum_distance_from_elements( true, $context, $args, array() );
-		$this->assertTrue( $okToInsert );
+		$ok_to_insert = Element_Constraints::meets_minimum_distance_from_elements( true, $context, $args, array() );
+		$this->assertTrue( $ok_to_insert );
 	}
 
 	public function test_meets_minimum_distance_from_elements_words() {
@@ -68,12 +68,12 @@ than 1200Something longer than 1200';
 			),
 		);
 
-		$okToInsert = Element_Constraints::meets_minimum_distance_from_elements( true, $context, $args, array() );
-		$this->assertFalse( $okToInsert );
+		$ok_to_insert = Element_Constraints::meets_minimum_distance_from_elements( true, $context, $args, array() );
+		$this->assertFalse( $ok_to_insert );
 
 		$context['index'] = 3;
-		$okToInsert = Element_Constraints::meets_minimum_distance_from_elements( true, $context, $args, array() );
-		$this->assertTrue( $okToInsert );
+		$ok_to_insert = Element_Constraints::meets_minimum_distance_from_elements( true, $context, $args, array() );
+		$this->assertTrue( $ok_to_insert );
 
 		$args['from_element'] = array(
 			'words' => 60,
@@ -81,12 +81,12 @@ than 1200Something longer than 1200';
 				'words' => 120,
 			),
 		);
-		$okToInsert = Element_Constraints::meets_minimum_distance_from_elements( true, $context, $args, array() );
-		$this->assertFalse( $okToInsert );
+		$ok_to_insert = Element_Constraints::meets_minimum_distance_from_elements( true, $context, $args, array() );
+		$this->assertFalse( $ok_to_insert );
 
 		$args['from_element']['blockquote'] = array( 'words' => 1 );
-		$okToInsert = Element_Constraints::meets_minimum_distance_from_elements( true, $context, $args, array() );
-		$this->assertTrue( $okToInsert );
+		$ok_to_insert = Element_Constraints::meets_minimum_distance_from_elements( true, $context, $args, array() );
+		$this->assertTrue( $ok_to_insert );
 	}
 
 	public function test_meets_minimum_distance_from_elements_characters() {
@@ -103,12 +103,12 @@ than 1200Something longer than 1200';
 			),
 		);
 
-		$okToInsert = Element_Constraints::meets_minimum_distance_from_elements( true, $context, $args, array() );
-		$this->assertFalse( $okToInsert );
+		$ok_to_insert = Element_Constraints::meets_minimum_distance_from_elements( true, $context, $args, array() );
+		$this->assertFalse( $ok_to_insert );
 
 		$context['index'] = 3;
-		$okToInsert = Element_Constraints::meets_minimum_distance_from_elements( true, $context, $args, array() );
-		$this->assertTrue( $okToInsert );
+		$ok_to_insert = Element_Constraints::meets_minimum_distance_from_elements( true, $context, $args, array() );
+		$this->assertTrue( $ok_to_insert );
 
 		$args['from_element'] = array(
 			'characters' => 450,
@@ -116,12 +116,12 @@ than 1200Something longer than 1200';
 				'characters' => 1500,
 			),
 		);
-		$okToInsert = Element_Constraints::meets_minimum_distance_from_elements( true, $context, $args, array() );
-		$this->assertFalse( $okToInsert );
+		$ok_to_insert = Element_Constraints::meets_minimum_distance_from_elements( true, $context, $args, array() );
+		$this->assertFalse( $ok_to_insert );
 
 		$args['from_element']['blockquote'] = array( 'characters' => 1 );
-		$okToInsert = Element_Constraints::meets_minimum_distance_from_elements( true, $context, $args, array() );
-		$this->assertTrue( $okToInsert );
+		$ok_to_insert = Element_Constraints::meets_minimum_distance_from_elements( true, $context, $args, array() );
+		$this->assertTrue( $ok_to_insert );
 	}
 
 }

--- a/tests/constraints/test-speed-bumps-injection-constraints.php
+++ b/tests/constraints/test-speed-bumps-injection-constraints.php
@@ -32,12 +32,12 @@ than 1200Something longer than 1200';
 			'maximum_inserts' => 1,
 		);
 
-		$okToInsert = Injection::less_than_maximum_number_of_inserts( true, array( 'index' => 2 ), $args, $already_inserted );
-		$this->assertFalse( $okToInsert );
+		$ok_to_insert = Injection::less_than_maximum_number_of_inserts( true, array( 'index' => 2 ), $args, $already_inserted );
+		$this->assertFalse( $ok_to_insert );
 
 		$args['maximum_inserts'] = 2;
-		$okToInsert = Injection::less_than_maximum_number_of_inserts( true, array( 'index' => 2 ), $args, $already_inserted );
-		$this->assertTrue( $okToInsert );
+		$ok_to_insert = Injection::less_than_maximum_number_of_inserts( true, array( 'index' => 2 ), $args, $already_inserted );
+		$this->assertTrue( $ok_to_insert );
 	}
 
 	public function test_no_speed_bump_inserted_here() {
@@ -49,11 +49,11 @@ than 1200Something longer than 1200';
 			),
 		);
 
-		$okToInsert = Injection::no_speed_bump_inserted_here( true, array( 'index' => 1 ), array( 'id' => 'speed_bump2' ), $already_inserted );
-		$this->assertFalse( $okToInsert );
+		$ok_to_insert = Injection::no_speed_bump_inserted_here( true, array( 'index' => 1 ), array( 'id' => 'speed_bump2' ), $already_inserted );
+		$this->assertFalse( $ok_to_insert );
 
-		$okToInsert = Injection::no_speed_bump_inserted_here( true, array( 'index' => 2 ), array( 'id' => 'speed_bump2' ), $already_inserted );
-		$this->assertTrue( $okToInsert );
+		$ok_to_insert = Injection::no_speed_bump_inserted_here( true, array( 'index' => 2 ), array( 'id' => 'speed_bump2' ), $already_inserted );
+		$this->assertTrue( $ok_to_insert );
 	}
 
 	public function test_meets_minimum_distance_from_other_inserts_paragraphs() {
@@ -78,20 +78,20 @@ than 1200Something longer than 1200';
 			),
 		);
 
-		$okToInsert = Injection::meets_minimum_distance_from_other_inserts( true, $context, $args, $already_inserted );
-		$this->assertFalse( $okToInsert );
+		$ok_to_insert = Injection::meets_minimum_distance_from_other_inserts( true, $context, $args, $already_inserted );
+		$this->assertFalse( $ok_to_insert );
 
 		$context['index'] = 3;
-		$okToInsert = Injection::meets_minimum_distance_from_other_inserts( true, $context, $args, $already_inserted );
-		$this->assertTrue( $okToInsert );
+		$ok_to_insert = Injection::meets_minimum_distance_from_other_inserts( true, $context, $args, $already_inserted );
+		$this->assertTrue( $ok_to_insert );
 
 		$args['from_speedbump']['speed_bump1'] = array( 'paragraphs' => 4 );
-		$okToInsert = Injection::meets_minimum_distance_from_other_inserts( true, $context, $args, $already_inserted );
-		$this->assertFalse( $okToInsert );
+		$ok_to_insert = Injection::meets_minimum_distance_from_other_inserts( true, $context, $args, $already_inserted );
+		$this->assertFalse( $ok_to_insert );
 
 		$args['from_speedbump']['speed_bump1'] = array( 'paragraphs' => 1 );
-		$okToInsert = Injection::meets_minimum_distance_from_other_inserts( true, $context, $args, $already_inserted );
-		$this->assertTrue( $okToInsert );
+		$ok_to_insert = Injection::meets_minimum_distance_from_other_inserts( true, $context, $args, $already_inserted );
+		$this->assertTrue( $ok_to_insert );
 	}
 
 	public function test_meets_minimum_distance_from_other_inserts_words() {
@@ -116,20 +116,20 @@ than 1200Something longer than 1200';
 			),
 		);
 
-		$okToInsert = Injection::meets_minimum_distance_from_other_inserts( true, $context, $args, $already_inserted );
-		$this->assertFalse( $okToInsert );
+		$ok_to_insert = Injection::meets_minimum_distance_from_other_inserts( true, $context, $args, $already_inserted );
+		$this->assertFalse( $ok_to_insert );
 
 		$context['index'] = 3;
-		$okToInsert = Injection::meets_minimum_distance_from_other_inserts( true, $context, $args, $already_inserted );
-		$this->assertTrue( $okToInsert );
+		$ok_to_insert = Injection::meets_minimum_distance_from_other_inserts( true, $context, $args, $already_inserted );
+		$this->assertTrue( $ok_to_insert );
 
 		$args['from_speedbump']['speed_bump1'] = array( 'words' => 200 );
-		$okToInsert = Injection::meets_minimum_distance_from_other_inserts( true, $context, $args, $already_inserted );
-		$this->assertFalse( $okToInsert );
+		$ok_to_insert = Injection::meets_minimum_distance_from_other_inserts( true, $context, $args, $already_inserted );
+		$this->assertFalse( $ok_to_insert );
 
 		$args['from_speedbump']['speed_bump1'] = array( 'words' => 20 );
-		$okToInsert = Injection::meets_minimum_distance_from_other_inserts( true, $context, $args, $already_inserted );
-		$this->assertTrue( $okToInsert );
+		$ok_to_insert = Injection::meets_minimum_distance_from_other_inserts( true, $context, $args, $already_inserted );
+		$this->assertTrue( $ok_to_insert );
 	}
 
 	public function test_meets_minimum_distance_from_other_inserts_characters() {
@@ -154,19 +154,19 @@ than 1200Something longer than 1200';
 			),
 		);
 
-		$okToInsert = Injection::meets_minimum_distance_from_other_inserts( true, $context, $args, $already_inserted );
-		$this->assertFalse( $okToInsert );
+		$ok_to_insert = Injection::meets_minimum_distance_from_other_inserts( true, $context, $args, $already_inserted );
+		$this->assertFalse( $ok_to_insert );
 
 		$context['index'] = 3;
-		$okToInsert = Injection::meets_minimum_distance_from_other_inserts( true, $context, $args, $already_inserted );
-		$this->assertTrue( $okToInsert );
+		$ok_to_insert = Injection::meets_minimum_distance_from_other_inserts( true, $context, $args, $already_inserted );
+		$this->assertTrue( $ok_to_insert );
 
 		$args['from_speedbump']['speed_bump1'] = array( 'characters' => 1500 );
-		$okToInsert = Injection::meets_minimum_distance_from_other_inserts( true, $context, $args, $already_inserted );
-		$this->assertFalse( $okToInsert );
+		$ok_to_insert = Injection::meets_minimum_distance_from_other_inserts( true, $context, $args, $already_inserted );
+		$this->assertFalse( $ok_to_insert );
 
 		$args['from_speedbump']['speed_bump1'] = array( 'characters' => 50 );
-		$okToInsert = Injection::meets_minimum_distance_from_other_inserts( true, $context, $args, $already_inserted );
-		$this->assertTrue( $okToInsert );
+		$ok_to_insert = Injection::meets_minimum_distance_from_other_inserts( true, $context, $args, $already_inserted );
+		$this->assertTrue( $ok_to_insert );
 	}
 }

--- a/tests/constraints/test-speed-bumps-text-constraints.php
+++ b/tests/constraints/test-speed-bumps-text-constraints.php
@@ -27,12 +27,12 @@ than 1200Something longer than 1200';
 		);
 
 		$args = array( 'minimum_content_length' => array( 'words' => 150 ) );
-		$okToInsert = Minimum_Text::content_is_long_enough_to_insert( true, $context, $args, array() );
-		$this->assertTrue( $okToInsert );
+		$ok_to_insert = Minimum_Text::content_is_long_enough_to_insert( true, $context, $args, array() );
+		$this->assertTrue( $ok_to_insert );
 
 		$args = array( 'minimum_content_length' => array( 'words' => 180 ) );
-		$okToInsert = Minimum_Text::content_is_long_enough_to_insert( true, $context, $args, array() );
-		$this->assertFalse( $okToInsert );
+		$ok_to_insert = Minimum_Text::content_is_long_enough_to_insert( true, $context, $args, array() );
+		$this->assertFalse( $ok_to_insert );
 	}
 
 	public function test_minimum_content_length_paragraphs() {
@@ -41,12 +41,12 @@ than 1200Something longer than 1200';
 		);
 
 		$args = array( 'minimum_content_length' => array( 'paragraphs' => 5 ) );
-		$okToInsert = Minimum_Text::content_is_long_enough_to_insert( true, $context, $args, array() );
-		$this->assertTrue( $okToInsert );
+		$ok_to_insert = Minimum_Text::content_is_long_enough_to_insert( true, $context, $args, array() );
+		$this->assertTrue( $ok_to_insert );
 
 		$args = array( 'minimum_content_length' => array( 'paragraphs' => 6 ) );
-		$okToInsert = Minimum_Text::content_is_long_enough_to_insert( true, $context, $args, array() );
-		$this->assertFalse( $okToInsert );
+		$ok_to_insert = Minimum_Text::content_is_long_enough_to_insert( true, $context, $args, array() );
+		$this->assertFalse( $ok_to_insert );
 
 	}
 
@@ -56,12 +56,12 @@ than 1200Something longer than 1200';
 		);
 
 		$args = array( 'minimum_content_length' => array( 'characters' => 1200 ) );
-		$okToInsert = Minimum_Text::content_is_long_enough_to_insert( true, $context, $args, array() );
-		$this->assertTrue( $okToInsert );
+		$ok_to_insert = Minimum_Text::content_is_long_enough_to_insert( true, $context, $args, array() );
+		$this->assertTrue( $ok_to_insert );
 
 		$args = array( 'minimum_content_length' => array( 'characters' => 1600 ) );
-		$okToInsert = Minimum_Text::content_is_long_enough_to_insert( true, $context, $args, array() );
-		$this->assertFalse( $okToInsert );
+		$ok_to_insert = Minimum_Text::content_is_long_enough_to_insert( true, $context, $args, array() );
+		$this->assertFalse( $ok_to_insert );
 	}
 
 	public function test_meets_minimum_distance_from_start_paragraphs() {
@@ -75,12 +75,12 @@ than 1200Something longer than 1200';
 			'index' => 1,
 		);
 
-		$okToInsert = Minimum_Text::meets_minimum_distance_from_start( true, $context, $args, array() );
-		$this->assertTrue( $okToInsert );
+		$ok_to_insert = Minimum_Text::meets_minimum_distance_from_start( true, $context, $args, array() );
+		$this->assertTrue( $ok_to_insert );
 
 		$context['index'] = 0;
-		$okToInsert = Minimum_Text::meets_minimum_distance_from_start( true, $context, $args, array() );
-		$this->assertFalse( $okToInsert );
+		$ok_to_insert = Minimum_Text::meets_minimum_distance_from_start( true, $context, $args, array() );
+		$this->assertFalse( $ok_to_insert );
 	}
 
 	public function test_meets_minimum_distance_from_start_words() {
@@ -94,12 +94,12 @@ than 1200Something longer than 1200';
 			'index' => 1,
 		);
 
-		$okToInsert = Minimum_Text::meets_minimum_distance_from_start( true, $context, $args, array() );
-		$this->assertTrue( $okToInsert );
+		$ok_to_insert = Minimum_Text::meets_minimum_distance_from_start( true, $context, $args, array() );
+		$this->assertTrue( $ok_to_insert );
 
 		$context['index'] = 0;
-		$okToInsert = Minimum_Text::meets_minimum_distance_from_start( true, $context, $args, array() );
-		$this->assertFalse( $okToInsert );
+		$ok_to_insert = Minimum_Text::meets_minimum_distance_from_start( true, $context, $args, array() );
+		$this->assertFalse( $ok_to_insert );
 	}
 
 	public function test_meets_minimum_distance_from_start_characters() {
@@ -113,12 +113,12 @@ than 1200Something longer than 1200';
 			'index' => 1,
 		);
 
-		$okToInsert = Minimum_Text::meets_minimum_distance_from_start( true, $context, $args, array() );
-		$this->assertTrue( $okToInsert );
+		$ok_to_insert = Minimum_Text::meets_minimum_distance_from_start( true, $context, $args, array() );
+		$this->assertTrue( $ok_to_insert );
 
 		$context['index'] = 0;
-		$okToInsert = Minimum_Text::meets_minimum_distance_from_start( true, $context, $args, array() );
-		$this->assertFalse( $okToInsert );
+		$ok_to_insert = Minimum_Text::meets_minimum_distance_from_start( true, $context, $args, array() );
+		$this->assertFalse( $ok_to_insert );
 	}
 
 	public function test_meets_minimum_distance_from_end_paragraphs() {
@@ -132,12 +132,12 @@ than 1200Something longer than 1200';
 			'index' => 1,
 		);
 
-		$okToInsert = Minimum_Text::meets_minimum_distance_from_end( true, $context, $args, array() );
-		$this->assertTrue( $okToInsert );
+		$ok_to_insert = Minimum_Text::meets_minimum_distance_from_end( true, $context, $args, array() );
+		$this->assertTrue( $ok_to_insert );
 
 		$context['index'] = 4;
-		$okToInsert = Minimum_Text::meets_minimum_distance_from_end( true, $context, $args, array() );
-		$this->assertFalse( $okToInsert );
+		$ok_to_insert = Minimum_Text::meets_minimum_distance_from_end( true, $context, $args, array() );
+		$this->assertFalse( $ok_to_insert );
 	}
 
 	public function test_meets_minimum_distance_from_end_words() {
@@ -151,12 +151,12 @@ than 1200Something longer than 1200';
 			'index' => 1,
 		);
 
-		$okToInsert = Minimum_Text::meets_minimum_distance_from_end( true, $context, $args, array() );
-		$this->assertTrue( $okToInsert );
+		$ok_to_insert = Minimum_Text::meets_minimum_distance_from_end( true, $context, $args, array() );
+		$this->assertTrue( $ok_to_insert );
 
 		$context['index'] = 4;
-		$okToInsert = Minimum_Text::meets_minimum_distance_from_end( true, $context, $args, array() );
-		$this->assertFalse( $okToInsert );
+		$ok_to_insert = Minimum_Text::meets_minimum_distance_from_end( true, $context, $args, array() );
+		$this->assertFalse( $ok_to_insert );
 	}
 
 	public function test_meets_minimum_distance_from_end_characters() {
@@ -170,11 +170,11 @@ than 1200Something longer than 1200';
 			'index' => 1,
 		);
 
-		$okToInsert = Minimum_Text::meets_minimum_distance_from_end( true, $context, $args, array() );
-		$this->assertTrue( $okToInsert );
+		$ok_to_insert = Minimum_Text::meets_minimum_distance_from_end( true, $context, $args, array() );
+		$this->assertTrue( $ok_to_insert );
 
 		$context['index'] = 4;
-		$okToInsert = Minimum_Text::meets_minimum_distance_from_end( true, $context, $args, array() );
-		$this->assertFalse( $okToInsert );
+		$ok_to_insert = Minimum_Text::meets_minimum_distance_from_end( true, $context, $args, array() );
+		$this->assertFalse( $ok_to_insert );
 	}
 }

--- a/tests/test-speed-bumps-integration.php
+++ b/tests/test-speed-bumps-integration.php
@@ -230,7 +230,7 @@ class Test_Speed_Bumps_Integration extends WP_UnitTestCase {
 			'last_ditch_fallback' => function( $context ) use ( $testcase ) {
 				$testcase->assertTrue( $context['last_ditch'] );
 				return true;
-			}
+			},
 		) );
 
 		$content = $this->get_dummy_content();
@@ -246,7 +246,7 @@ class Test_Speed_Bumps_Integration extends WP_UnitTestCase {
 			'last_ditch_fallback' => function( $context ) use ( $testcase ) {
 				$testcase->assertTrue( $context['last_ditch'] );
 				return false;
-			}
+			},
 		) );
 		$this->assertNotContains( $new_content, 'second speed bump' );
 	}

--- a/tests/test-speed-bumps-integration.php
+++ b/tests/test-speed-bumps-integration.php
@@ -193,7 +193,7 @@ class Test_Speed_Bumps_Integration extends WP_UnitTestCase {
 			'minimum_content_length' => 1500,
 			'from_start' => 0,
 			'from_end' => null,
-			'last_ditch_fallback' => true
+			'last_ditch_fallback' => true,
 		) );
 
 		$content = $this->get_dummy_content();
@@ -208,7 +208,7 @@ class Test_Speed_Bumps_Integration extends WP_UnitTestCase {
 			'minimum_inserts' => 2,
 			'from_start' => array( 'paragraphs' => 6 ),
 			'from_end' => null,
-			'last_ditch_fallback' => true
+			'last_ditch_fallback' => true,
 		) );
 
 		$content = $this->get_dummy_content();

--- a/tests/test-speed-bumps-integration.php
+++ b/tests/test-speed-bumps-integration.php
@@ -186,6 +186,22 @@ class Test_Speed_Bumps_Integration extends WP_UnitTestCase {
 
 	}
 
+	public function test_speed_bump_last_ditch_insertion() {
+		\Speed_Bumps()->register_speed_bump( 'speed_bump1', array(
+			'string_to_inject' => function( $context ) { return ( ! empty( $context['last_ditch'] ) ) ? 'last ditch' : 'normal insert'; },
+			'minimum_content_length' => 1500,
+			'from_start' => 0,
+			'from_end' => null,
+			'last_ditch_fallback' => true
+		) );
+
+		$content = $this->get_dummy_content();
+		$new_content = Speed_Bumps()->insert_speed_bumps( $content );
+
+		$this->assertSpeedBumpAtParagraph( $new_content, 19, 'last ditch' );
+
+	}
+
 	private function get_dummy_content() {
 		$content = <<<EOT
 Far far away, behind the word mountains, far from the countries Vokalia and Consonantia, there live the blind texts.

--- a/tests/test-speed-bumps-integration.php
+++ b/tests/test-speed-bumps-integration.php
@@ -199,7 +199,22 @@ class Test_Speed_Bumps_Integration extends WP_UnitTestCase {
 		$new_content = Speed_Bumps()->insert_speed_bumps( $content );
 
 		$this->assertSpeedBumpAtParagraph( $new_content, 19, 'last ditch' );
+	}
 
+	public function test_speed_bump_last_ditch_insertion_minimum_inserts() {
+		\Speed_Bumps()->register_speed_bump( 'speed_bump1', array(
+			'string_to_inject' => function( $context ) { return ( ! empty( $context['last_ditch'] ) ) ? 'last ditch' : 'normal insert'; },
+			'minimum_inserts' => 2,
+			'from_start' => array( 'paragraphs' => 6 ),
+			'from_end' => null,
+			'last_ditch_fallback' => true
+		) );
+
+		$content = $this->get_dummy_content();
+		$new_content = Speed_Bumps()->insert_speed_bumps( $content );
+
+		$this->assertSpeedBumpAtParagraph( $new_content, 14, 'normal insert' );
+		$this->assertSpeedBumpAtParagraph( $new_content, 20, 'last ditch' );
 	}
 
 	private function get_dummy_content() {

--- a/tests/test-speed-bumps-integration.php
+++ b/tests/test-speed-bumps-integration.php
@@ -219,13 +219,16 @@ class Test_Speed_Bumps_Integration extends WP_UnitTestCase {
 	}
 
 	public function test_speed_bump_last_ditch_insertion_callable() {
+		// Prepare the test case class to pass into closures (for PHP <=5.3)
+		$testcase = $this;
+
 		\Speed_Bumps()->register_speed_bump( 'speed_bump1', array(
 			'string_to_inject' => function() { return 'last ditch'; },
 			'minimum_content_length' => 1500,
 			'from_start' => 200000,
 			'from_end' => null,
-			'last_ditch_fallback' => function( $context ) {
-				$this->assertTrue( $context['last_ditch'] );
+			'last_ditch_fallback' => function( $context ) use ( $testcase ) {
+				$testcase->assertTrue( $context['last_ditch'] );
 				return true;
 			}
 		) );
@@ -240,8 +243,8 @@ class Test_Speed_Bumps_Integration extends WP_UnitTestCase {
 			'minimum_content_length' => 1500,
 			'from_start' => 200000,
 			'from_end' => null,
-			'last_ditch_fallback' => function( $context ) {
-				$this->assertTrue( $context['last_ditch'] );
+			'last_ditch_fallback' => function( $context ) use ( $testcase ) {
+				$testcase->assertTrue( $context['last_ditch'] );
 				return false;
 			}
 		) );


### PR DESCRIPTION
Adds a argument for "last_ditch_fallback" to the options on registering
a speed bump, which can be either boolean or callable.

If "true", a speed bump will be inserted at the end of the content if a
defined minimum number of insertions haven't been met (defaults to 1).

If "callable", the function provided will be called, with the same
'$args' and '$already_inserted' parameters used by other constraints,
after the end of the context has been processed, and can return true or
false to indicate whether to insert a last ditch speed bump at this
location. (The $can_insert parameter would be meaningless here, so is
left out.)

Connected to #81