### PR TITLE
Remove minimum_content_length filter after running once

### DIFF
--- a/inc/constraints/elements/class-shortcode.php
+++ b/inc/constraints/elements/class-shortcode.php
@@ -1,7 +1,7 @@
 <?php
 namespace Speed_Bumps\Constraints\Elements;
 
-class Shortcode extends Constraint_Abstract{
+class Shortcode extends Constraint_Abstract {
 	public function paragraph_not_contains_element( $paragraph ) {
 		if ( preg_match_all( '/' . get_shortcode_regex() . '/s', $paragraph, $matches, PREG_SET_ORDER ) ) {
 			return false;

--- a/inc/constraints/text/class-minimum-text.php
+++ b/inc/constraints/text/class-minimum-text.php
@@ -51,6 +51,11 @@ class Minimum_Text {
 			}
 		}
 
+		// This constraint should only need to be run once. If we've gotten to this point, then the content
+		// *is* long enough to insert, so this filter can be removed, rather than recalulating on every
+		// paragraph.
+		remove_filter( current_filter(), '\\' . __CLASS__ . '::' .  __FUNCTION__ );
+
 		return $can_insert;
 	}
 

--- a/inc/constraints/text/class-minimum-text.php
+++ b/inc/constraints/text/class-minimum-text.php
@@ -54,7 +54,7 @@ class Minimum_Text {
 		// This constraint should only need to be run once. If we've gotten to this point, then the content
 		// *is* long enough to insert, so this filter can be removed, rather than recalulating on every
 		// paragraph.
-		remove_filter( current_filter(), '\\' . __CLASS__ . '::' .  __FUNCTION__ );
+		remove_filter( current_filter(), '\\' . __CLASS__ . '::' . __FUNCTION__ );
 
 		return $can_insert;
 	}

--- a/tests/test-speed-bumps-in-readme.php
+++ b/tests/test-speed-bumps-in-readme.php
@@ -184,7 +184,7 @@ EOT;
 
 	private function assertSpeedBumpAtParagraph( $content_to_test, $speed_bump_paragraph, $injected_string ) {
 		$parts = preg_split( '/\n\s*\n/', $content_to_test );
-		$actual_speed_bump_paragraph = array_search( $injected_string, $parts );
+		$actual_speed_bump_paragraph = array_search( $injected_string, $parts, true );
 
 		if ( false === $actual_speed_bump_paragraph ) {
 			$this->fail( 'The speed bump is not in the content' );

--- a/tests/test-speed-bumps-integration.php
+++ b/tests/test-speed-bumps-integration.php
@@ -308,7 +308,7 @@ EOT;
 
 	private function assertSpeedBumpAtParagraph( $content_to_test, $speed_bump_paragraph, $injected_string ) {
 		$parts = preg_split( '/\n\s*\n/', $content_to_test );
-		$actual_speed_bump_paragraph = array_search( $injected_string, $parts );
+		$actual_speed_bump_paragraph = array_search( $injected_string, $parts, true );
 
 		if ( false === $actual_speed_bump_paragraph ) {
 			$this->fail( 'The speed bump is not in the content' );


### PR DESCRIPTION
Its safe to assume that the length of a piece of content doesn't change from
its first paragraph to its last. Removing the 'content_is_long_enough_to_insert'
constraint filter after the first time it's processed can save an enormous
amount of processing time, especially in posts with hundreds of paragraphs,
by only calclulating the minimum text length constraint once per speed bump
on a given piece of content.

