### PR TITLE
Clone hooks when backing up, rather than passing by reference

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -47,7 +47,7 @@ module.exports = function( grunt ) {
 				src: './',
 			},
 			options: {
-				bin: "vendor/bin/phpcs --extensions=php --ignore=\"*/vendor/*,*/node_modules/*,dev.php\"",
+				bin: "vendor/bin/phpcs --extensions=php --ignore=\"*/vendor/*,*/node_modules/*",
 				standard: "phpcs.ruleset.xml"
 			}
 		}

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -47,7 +47,7 @@ module.exports = function( grunt ) {
 				src: './',
 			},
 			options: {
-				bin: "vendor/bin/phpcs --extensions=php --ignore=\"*/vendor/*,*/node_modules/*",
+				bin: "vendor/bin/phpcs --extensions=php --ignore=\"*/vendor/*,*/node_modules/*\"",
 				standard: "phpcs.ruleset.xml"
 			}
 		}

--- a/inc/constraints/content/class-injection.php
+++ b/inc/constraints/content/class-injection.php
@@ -31,7 +31,6 @@ class Injection {
 	 * by the 'maximum_inserts' argument on speed bump registration.
 	 */
 	public static function less_than_maximum_number_of_inserts( $can_insert, $context, $args, $already_inserted ) {
-		global $_wp_filters_backed_up, $wp_filter;
 
 		$this_speed_bump_insertions = array_filter( $already_inserted,
 			function( $insertion ) use ( $args ) { return $insertion['speed_bump_id'] === $args['id']; }

--- a/phpcs.ruleset.xml
+++ b/phpcs.ruleset.xml
@@ -11,4 +11,6 @@
 		<exclude name="WordPress.VIP.SuperGlobalInputUsage" />
 		<exclude name="WordPress.VIP.ValidatedSanitizedInput" />
 	</rule>
+
+	<exclude name="Squiz.Commenting.LongConditionClosingComment"/>
 </ruleset>

--- a/phpcs.ruleset.xml
+++ b/phpcs.ruleset.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0"?>
-<ruleset name="Shortcake">
+<ruleset name="Speed Bumps">
 	<description>Sniffs for the coding standards of the Speed Bumps plugin</description>
 
 	<extensions>*.php</extensions>
-	<exclude-pattern>/vendor/*</exclude-pattern>
+	<exclude-pattern>*/vendor/*,*/node_modules/*</exclude-pattern>
 
 	<rule ref="WordPress-VIP">
 		<exclude name="WordPress.CSRF.NonceVerification" />
@@ -11,6 +11,4 @@
 		<exclude name="WordPress.VIP.SuperGlobalInputUsage" />
 		<exclude name="WordPress.VIP.ValidatedSanitizedInput" />
 	</rule>
-
-	<exclude name="Squiz.Commenting.LongConditionClosingComment"/>
 </ruleset>

--- a/speed-bumps.php
+++ b/speed-bumps.php
@@ -170,9 +170,9 @@ class Speed_Bumps {
 				 */
 				do_action( 'speed_bumps_constraints_completed', $speed_bump_filter );
 
-			} // end foreach() loop over filters at potential insertion point
+			} // End foreach(). [loop over filters at potential insertion point]
 
-		} // end foreach() loop over paragraphs in content
+		} // End foreach(). [loop over paragraphs in content]
 
 		// Apply "last ditch" insertion rules for any speed bumps that implement them
 		$context['last_ditch'] = true;

--- a/speed-bumps.php
+++ b/speed-bumps.php
@@ -169,8 +169,10 @@ class Speed_Bumps {
 				 * @param array  $context           Current insertion point context
 				 */
 				do_action( 'speed_bumps_constraints_completed', $speed_bump_filter );
-			}
-		}
+
+			} // end foreach() loop over filters at potential insertion point
+
+		} // end foreach() loop over paragraphs in content
 
 		// Apply "last ditch" insertion rules for any speed bumps that implement them
 		$context['last_ditch'] = true;

--- a/speed-bumps.php
+++ b/speed-bumps.php
@@ -374,7 +374,7 @@ class Speed_Bumps {
 		global $_wp_filters_backed_up, $wp_filter;
 
 		if ( in_array( $filter_id, Speed_Bumps()->get_speed_bumps_filters(), true ) ) {
-			$_wp_filters_backed_up[ $filter_id ] = $wp_filter[ $filter_id ];
+			$_wp_filters_backed_up[ $filter_id ] = is_object( $wp_filter[ $filter_id ] ) ? clone $wp_filter[ $filter_id ] : $wp_filter[ $filter_id ];
 			remove_all_filters( $filter_id );
 			add_filter( $filter_id, '__return_false' );
 		}
@@ -403,7 +403,7 @@ class Speed_Bumps {
 		if ( isset( $wp_filter[ $filter_id ] )
 				&& in_array( $filter_id, Speed_Bumps()->get_speed_bumps_filters(), true ) ) {
 
-			$_wp_filters_backed_up[ $filter_id ] = $wp_filter[ $filter_id ];
+			$_wp_filters_backed_up[ $filter_id ] = is_object( $wp_filter[ $filter_id ] ) ? clone $wp_filter[ $filter_id ] : $wp_filter[ $filter_id ];
 			remove_all_filters( $filter_id );
 
 			// Restore the speed bump after the current insertion point has been processed

--- a/speed-bumps.php
+++ b/speed-bumps.php
@@ -170,9 +170,8 @@ class Speed_Bumps {
 				 */
 				do_action( 'speed_bumps_constraints_completed', $speed_bump_filter );
 
-			} // End foreach(). [loop over filters at potential insertion point]
-
-		} // End foreach(). [loop over paragraphs in content]
+			} // End foreach().
+		} // End foreach().
 
 		// Apply "last ditch" insertion rules for any speed bumps that implement them
 		$context['last_ditch'] = true;

--- a/speed-bumps.php
+++ b/speed-bumps.php
@@ -170,8 +170,9 @@ class Speed_Bumps {
 				 */
 				do_action( 'speed_bumps_constraints_completed', $speed_bump_filter );
 
-			} // End foreach().
-		} // End foreach().
+			} // @codingStandardsIgnoreLine End foreach() loop through filters at insertion point
+
+		} // @codingStandardsIgnoreLine End foreach() loop through paragraphs.
 
 		// Apply "last ditch" insertion rules for any speed bumps that implement them
 		$context['last_ditch'] = true;


### PR DESCRIPTION
Since the change in WP core 4.7 where each filter hook is an instance of the WP_Hook class rather than an array, the way we were previously backing up filters for temporarily disabled speed bumps by assigning them to the $_wp_filters_backed_up global was behaving unexpectedly - because when you define a variable as an instance of a class, that class is passed by reference rather than cloned.

We can replicate the old behavior by specifying that we want to clone. The old behavior is left in place for pre-4.7 environments, to avoid fatals when trying to clone arrays.

Connected to #85.